### PR TITLE
Add business logic of extension

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -26,5 +26,5 @@
       "js": ["src/scripts/content_script.js"]
     }
   ],
-  "permissions": ["tabs"]
+  "permissions": ["tabs", "storage"]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,25 +1,30 @@
 {
-    "manifest_version": 2,
-    "name": "Usage-Monitor",
-    "version": "1.0",
-    "description": "Use this extension to track usage of websites you visit!",
+  "manifest_version": 2,
+  "name": "Usage-Monitor",
+  "version": "1.0",
+  "description": "Use this extension to track usage of websites you visit!",
 
-    "icons": {
-        "128": "src/icons/128.png",
-        "48": "src/icons/48.png",
-        "32": "src/icons/32.png",
-        "16": "src/icons/16.png"
-    },
+  "icons": {
+    "128": "src/icons/128.png",
+    "48": "src/icons/48.png",
+    "32": "src/icons/32.png",
+    "16": "src/icons/16.png"
+  },
 
-    "browser_action": {
-        "default_icon": "src/icons/16.png",
-        "default_popup": "src/views/popup.html"
-    },
+  "browser_action": {
+    "default_icon": "src/icons/16.png",
+    "default_popup": "src/views/popup.html"
+  },
 
-    "background": {
-        "scripts": [
-            "src/scripts/eventPage.js"
-        ],
-        "persistence": false
+  "background": {
+    "scripts": ["src/scripts/background.js"],
+    "persistence": false
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["src/scripts/content_script.js"]
     }
+  ],
+  "permissions": ["tabs"]
 }

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -1,8 +1,31 @@
 // listen for message from content script
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
-  if (request.task === "update") {
-    console.log(
-      "hostname and time is" + request.host + " " + request.timeSpent
-    );
-  }
+  if (request.task === "updateUsageData")
+    handleUpdateUsageData(request.hostname, request.timeSpent);
 });
+
+/*
+extension will be storing data in chrome storage 
+using key "usageData";
+"usageData" is object with hostname as key and timespent 
+in seconds as value;
+usageData = {
+  "hostname1" : "timeSpent",
+  "hostname2" : "timeSpent"
+}
+*/
+
+function handleUpdateUsageData(hostname, timeSpent) {
+  chrome.storage.sync.get(["usageData"], function (result) {
+    let usageData = result.usageData;
+    // if usageData or usageData[hostname] doesn't exist
+    if (usageData === undefined) usageData = {};
+    if (usageData[hostname] === undefined) usageData[hostname] = 0;
+
+    usageData[hostname] += timeSpent;
+
+    chrome.storage.sync.set({ usageData: usageData }, function () {
+      console.log("updated data is: ", usageData);
+    });
+  });
+}

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -1,0 +1,8 @@
+// listen for message from content script
+chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
+  if (request.task === "update") {
+    console.log(
+      "hostname and time is" + request.host + " " + request.timeSpent
+    );
+  }
+});

--- a/src/scripts/content_script.js
+++ b/src/scripts/content_script.js
@@ -1,0 +1,37 @@
+//hostname remains constant for content_script lifetime
+const hostname = location.hostname;
+
+let start = Date.now();
+let stop = undefined;
+let timeSpent = undefined;
+
+document.addEventListener("visibilitychange", handleVisibilityChange, false);
+
+function handleMessage(time) {
+  let info = {
+    task: "update",
+    host: hostname,
+    timeSpent: time,
+  };
+  chrome.runtime.sendMessage(info);
+}
+
+function updateTimeSpent() {
+  stop = Date.now();
+  // Date.now() returns time in milliseconds since unix epoch,
+  // divide by 1000 to get time in seconds
+  timeSpent = (stop - start) / 1000;
+  handleMessage(Math.floor(timeSpent));
+}
+
+function handleVisibilityChange() {
+  let isVisible = document.visibilityState === "visible";
+  let isHidden = document.visibilityState === "hidden";
+  let isUnloaded = document.visibilityState === "unloaded";
+
+  if (isHidden || isUnloaded) {
+    updateTimeSpent();
+  } else if (isVisible) {
+    start = Date.now();
+  }
+}

--- a/src/scripts/content_script.js
+++ b/src/scripts/content_script.js
@@ -1,28 +1,21 @@
-//hostname remains constant for content_script lifetime
+//hostname remains same for content_script lifetime
 const hostname = location.hostname;
 
 let start = Date.now();
-let stop = undefined;
-let timeSpent = undefined;
+let stop = null;
+let timeSpent = null;
+
+const saveAfter = 60 * 1000;
+
+//save data every 60 second incase crash or anything unexpected happens
+setInterval(function () {
+  if (document.visibilityState === "visible") {
+    updateTimeSpent();
+    start = Date.now();
+  }
+}, saveAfter);
 
 document.addEventListener("visibilitychange", handleVisibilityChange, false);
-
-function handleMessage(time) {
-  let info = {
-    task: "update",
-    host: hostname,
-    timeSpent: time,
-  };
-  chrome.runtime.sendMessage(info);
-}
-
-function updateTimeSpent() {
-  stop = Date.now();
-  // Date.now() returns time in milliseconds since unix epoch,
-  // divide by 1000 to get time in seconds
-  timeSpent = (stop - start) / 1000;
-  handleMessage(Math.floor(timeSpent));
-}
 
 function handleVisibilityChange() {
   let isVisible = document.visibilityState === "visible";
@@ -34,4 +27,21 @@ function handleVisibilityChange() {
   } else if (isVisible) {
     start = Date.now();
   }
+}
+
+function updateTimeSpent() {
+  stop = Date.now();
+  // Date.now() returns time in milliseconds since unix epoch,
+  // divide by 1000 to get time in seconds
+  timeSpent = (stop - start) / 1000;
+  handleMessage(Math.floor(timeSpent));
+}
+
+function handleMessage(time) {
+  let info = {
+    task: "updateUsageData",
+    hostname: hostname,
+    timeSpent: time,
+  };
+  chrome.runtime.sendMessage(info);
 }


### PR DESCRIPTION
## Description

Content script gets loaded with each page update. so we will be using it to measure time
using pageVisibility api
it sends a message to background script with hostname and timeSpent:
1. if visibility changes: either hidden or page unloads
2. at every 60 seconds, to save data in case something unexpected like a crash happens

background script creates a "usageData" object with ``hostname`` as ``key`` and ``time spent``  as ``value.``
it updates every time a message is received from content Script

## Related Issue
resolves issue #7 

# Checklist
- [ ] Test
- [ ] Translations
- [ ] Documentations

## How Has This Been Tested?
1. clone this repo
2. goto chrome->extensions-> load_unpacked
3. for now, click on inspect background page , it is currently logging data as storage updates.
4. open different site and monitor data.

# Screenshots
![usage-monitor](https://user-images.githubusercontent.com/63513250/101935671-6ca22200-3c05-11eb-9380-68ac65aac4d0.png)
## Additional Info
popup page needs to updated in order to utilize changes made in this PR.