### PR TITLE
Add popup and options page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -20,6 +20,7 @@
     "scripts": ["src/scripts/background.js"],
     "persistence": false
   },
+  "options_page": "src/views/options.html",
   "content_scripts": [
     {
       "matches": ["<all_urls>"],

--- a/src/scripts/content_script.js
+++ b/src/scripts/content_script.js
@@ -5,9 +5,9 @@ let start = Date.now();
 let stop = null;
 let timeSpent = null;
 
-const saveAfter = 60 * 1000;
+const saveAfter = 3 * 1000;
 
-//save data every 60 second incase crash or anything unexpected happens
+//save data every 3 second incase crash or anything unexpected happens
 setInterval(function () {
   if (document.visibilityState === "visible") {
     updateTimeSpent();

--- a/src/scripts/options.js
+++ b/src/scripts/options.js
@@ -6,3 +6,5 @@ async function generateList() {
   createList(a.usageData);
 }
 generateList();
+// update page every 10 seconds
+setInterval(generateList, 10000);

--- a/src/scripts/options.js
+++ b/src/scripts/options.js
@@ -1,0 +1,8 @@
+import getUsageStats from "./utils/getUsageStats.js";
+import { createList } from "./utils/updateDom.js";
+
+async function generateList() {
+  let a = await getUsageStats();
+  createList(a.usageData);
+}
+generateList();

--- a/src/scripts/options.js
+++ b/src/scripts/options.js
@@ -8,3 +8,12 @@ async function generateList() {
 generateList();
 // update page every 10 seconds
 setInterval(generateList, 10000);
+
+// reset button
+
+const resetBtn = document.querySelector("#resetBtn");
+resetBtn.addEventListener("click", () => {
+  chrome.storage.sync.set({ usageData: {} }, function () {
+    alert("data reset successful!");
+  });
+});

--- a/src/scripts/options.js
+++ b/src/scripts/options.js
@@ -6,14 +6,15 @@ async function generateList() {
   createList(a.usageData);
 }
 generateList();
-// update page every 10 seconds
-setInterval(generateList, 10000);
+// update page every 1 seconds
+setInterval(generateList, 1000);
 
 // reset button
 
 const resetBtn = document.querySelector("#resetBtn");
 resetBtn.addEventListener("click", () => {
   chrome.storage.sync.set({ usageData: {} }, function () {
-    alert("data reset successful!");
+    alert("data reset successful! updating page in few seconds automatically");
+    generateList();
   });
 });

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -1,9 +1,13 @@
 import getUsageStats from "./utils/getUsageStats.js";
 import { createList, createListItem } from "./utils/updateDom.js";
+import getTimeString from "./utils/time.js";
 
 function updateMostVisitedSites(stats) {
   let timeSpentValues = Object.values(stats);
-  const topTimeSpentValues = timeSpentValues.sort().slice(0, 5);
+  timeSpentValues.sort(function (a, b) {
+    return a - b;
+  });
+  let topTimeSpentValues = timeSpentValues.reverse().slice(0, 5);
   let topStats = {};
 
   for (let i in topTimeSpentValues) {
@@ -29,7 +33,10 @@ function updateCurrentSite(stats) {
         .replace("http://", "")
         .replace("https://", "")
         .split(/[/?#]/)[0];
-      let currentSite = createListItem(hostname, stats[hostname]);
+      let currentSite = createListItem(
+        hostname,
+        getTimeString(stats[hostname])
+      );
       let currentSiteSpan = document.querySelector("#currentSite");
       currentSiteSpan.innerHTML = "";
       currentSiteSpan.appendChild(currentSite);
@@ -43,5 +50,5 @@ async function updatePage() {
   updateCurrentSite(stats);
 }
 updatePage();
-// update page every 10 seconds
-setInterval(updatePage, 10000);
+// update page every 3 seconds
+setInterval(updatePage, 3000);

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -1,0 +1,47 @@
+import getUsageStats from "./utils/getUsageStats.js";
+import { createList, createListItem } from "./utils/updateDom.js";
+
+function updateMostVisitedSites(stats) {
+  let timeSpentValues = Object.values(stats);
+  const topTimeSpentValues = timeSpentValues.sort().slice(0, 5);
+  let topStats = {};
+
+  for (let i in topTimeSpentValues) {
+    for (let key in stats) {
+      if (stats[key] === topTimeSpentValues[i]) {
+        topStats[key] = topTimeSpentValues[i];
+        break;
+      }
+    }
+  }
+  createList(topStats);
+}
+
+function updateCurrentSite(stats) {
+  chrome.tabs.query(
+    {
+      active: true,
+      currentWindow: true,
+    },
+    (tabs) => {
+      let url = tabs[0].url;
+      let hostname = url
+        .replace("http://", "")
+        .replace("https://", "")
+        .split(/[/?#]/)[0];
+      let currentSite = createListItem(hostname, stats[hostname]);
+      let currentSiteSpan = document.querySelector("#currentSite");
+      currentSiteSpan.innerHTML = "";
+      currentSiteSpan.appendChild(currentSite);
+    }
+  );
+}
+async function updatePage() {
+  let a = await getUsageStats();
+  const stats = a.usageData;
+  updateMostVisitedSites(stats);
+  updateCurrentSite(stats);
+}
+updatePage();
+// update page every 10 seconds
+setInterval(updatePage, 10000);

--- a/src/scripts/utils/getUsageStats.js
+++ b/src/scripts/utils/getUsageStats.js
@@ -1,0 +1,12 @@
+// get list from storage
+let getUsageStats = async () => {
+  let p = new Promise((resolve, reject) => {
+    chrome.storage.sync.get(["usageData"], (result) => {
+      resolve(result);
+    });
+  });
+  const stats = await p;
+  return stats;
+};
+
+export default getUsageStats;

--- a/src/scripts/utils/time.js
+++ b/src/scripts/utils/time.js
@@ -1,0 +1,23 @@
+/*
+convert seconds to proper displayable format
+for ex :
+124s as 2m 4s
+3664s as 1h 1m 4s
+*/
+
+function display(timeSpent) {
+  if (timeSpent < 60) {
+    return `${timeSpent}s`;
+  } else if (timeSpent < 3600) {
+    const minutes = Math.floor(timeSpent / 60);
+    const seconds = Math.floor(timeSpent % 60);
+    return `${minutes}m ${seconds}s`;
+  } else {
+    const hours = Math.floor(timeSpent / 3600);
+    const minutes = Math.floor((timeSpent % 3600) / 60);
+    const seconds = Math.floor(timeSpent % 60);
+    return `${hours}h ${minutes}m ${seconds}s`;
+  }
+}
+
+export default display;

--- a/src/scripts/utils/time.js
+++ b/src/scripts/utils/time.js
@@ -5,7 +5,7 @@ for ex :
 3664s as 1h 1m 4s
 */
 
-function display(timeSpent) {
+function getTimeString(timeSpent) {
   if (timeSpent < 60) {
     return `${timeSpent}s`;
   } else if (timeSpent < 3600) {
@@ -20,4 +20,4 @@ function display(timeSpent) {
   }
 }
 
-export default display;
+export default getTimeString;

--- a/src/scripts/utils/updateDom.js
+++ b/src/scripts/utils/updateDom.js
@@ -1,0 +1,28 @@
+import display from "./time.js";
+let createListItem = (hostname, timeSpent) => {
+  let listItem = document.createElement("li");
+  listItem.classList.add("siteStats");
+
+  let hostnameSpan = document.createElement("span");
+  hostnameSpan.textContent = hostname;
+  hostnameSpan.classList.add("hostname");
+
+  let timeSpentSpan = document.createElement("span");
+  timeSpentSpan.textContent = timeSpent;
+  timeSpentSpan.classList.add("timeSpent");
+
+  listItem.append(hostnameSpan, timeSpentSpan);
+  return listItem;
+};
+let createList = (usageStats) => {
+  let list = document.querySelector("ul");
+  const hosts = Object.keys(usageStats);
+  console.log(usageStats["archive.org"]);
+  hosts.forEach((host) => {
+    const timeSpent = display(usageStats[host]);
+    const hostEntry = createListItem(host, timeSpent);
+    list.appendChild(hostEntry);
+  });
+};
+
+export { createListItem, createList };

--- a/src/scripts/utils/updateDom.js
+++ b/src/scripts/utils/updateDom.js
@@ -17,7 +17,6 @@ let createListItem = (hostname, timeSpent) => {
 let createList = (usageStats) => {
   let list = document.querySelector("ul");
   const hosts = Object.keys(usageStats);
-  console.log(usageStats["archive.org"]);
   hosts.forEach((host) => {
     const timeSpent = display(usageStats[host]);
     const hostEntry = createListItem(host, timeSpent);

--- a/src/scripts/utils/updateDom.js
+++ b/src/scripts/utils/updateDom.js
@@ -1,4 +1,4 @@
-import display from "./time.js";
+import getTimeString from "./time.js";
 let createListItem = (hostname, timeSpent) => {
   if (!hostname) return;
   let listItem = document.createElement("li");
@@ -17,9 +17,10 @@ let createListItem = (hostname, timeSpent) => {
 };
 let createList = (usageStats) => {
   let list = document.querySelector("ul");
+  list.innerHTML = "";
   const hosts = Object.keys(usageStats);
   hosts.forEach((host) => {
-    const timeSpent = display(usageStats[host]);
+    const timeSpent = getTimeString(usageStats[host]);
     const hostEntry = createListItem(host, timeSpent);
     list.appendChild(hostEntry);
   });

--- a/src/scripts/utils/updateDom.js
+++ b/src/scripts/utils/updateDom.js
@@ -1,5 +1,6 @@
 import display from "./time.js";
 let createListItem = (hostname, timeSpent) => {
+  if (!hostname) return;
   let listItem = document.createElement("li");
   listItem.classList.add("siteStats");
 

--- a/src/styles/common.css
+++ b/src/styles/common.css
@@ -1,0 +1,108 @@
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Serif:wght@500&family=Kreon:wght@600&family=Montserrat:wght@300;400;700&display=swap");
+
+body {
+  margin-top: 0px;
+  font-family: "Montserrat", sans-serif;
+  background: #ecf0f1;
+  background-color: #cdc9c3;
+  height: auto;
+}
+
+/*****************************HEADER STYLES*****************************/
+
+header {
+  text-align: center;
+}
+header h1 {
+  font-family: "Kreon", serif;
+  font-size: 2.7rem;
+  font-weight: 300;
+  margin: 15px 0;
+  color: #2c3e50;
+  color: #333456;
+}
+header h3 {
+  color: #18537a;
+  font-weight: 300;
+}
+
+/*****************************LIST STYLES*****************************/
+
+h3 {
+  font-family: "IBM Plex Serif", serif;
+  text-align: center;
+  color: #532e1c;
+  font-size: large;
+  font-weight: 300;
+  margin: 0;
+  margin-bottom: 4px;
+}
+
+li {
+  list-style: none;
+}
+
+.list {
+  position: relative;
+  width: 20rem;
+  margin: 0;
+  padding: 2px;
+}
+
+.siteStats {
+  width: 100%;
+  height: auto;
+  line-height: 1.5;
+  font-size: 20px;
+  padding: 0 2px;
+  color: #34495e;
+  transition: all 0.3s ease;
+}
+
+.siteStats:hover {
+  cursor: pointer;
+}
+
+span.hostname {
+  color: #433d3c;
+}
+
+span.timeSpent {
+  color: blue;
+  position: absolute;
+  right: 0px;
+}
+
+/********** reset buttons *****************/
+.btn {
+  outline: none;
+  border: none;
+  cursor: pointer;
+  display: block;
+  position: relative;
+  background-color: #ac2e25;
+  font-size: 16px;
+  font-weight: 300;
+  color: white;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  padding: 10px 25px;
+  margin: 10px auto 25px;
+  border-radius: 20px;
+  box-shadow: 0 6px #ca4e4a;
+}
+
+.btn:hover {
+  box-shadow: 0 4px #ca534f;
+  bottom: -2px;
+}
+
+.btn:active {
+  box-shadow: none;
+  bottom: -6px;
+}
+.btn {
+  position: fixed;
+  bottom: 0px;
+  right: 12px;
+}

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -1,0 +1,8 @@
+body {
+  background-color: white;
+}
+div {
+  margin: auto;
+  width: 400px;
+  padding: 10px;
+}

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -1,0 +1,79 @@
+@import url("https://fonts.googleapis.com/css?family=Montserrat:300,400,700");
+
+body {
+  margin-top: 0px;
+  font-family: "Montserrat", sans-serif;
+  background: #ecf0f1;
+  height: auto;
+  width: 20rem;
+}
+
+/*****************************HEADER STYLES*****************************/
+
+header {
+  text-align: center;
+}
+header h1 {
+  font-size: 2.7rem;
+  font-weight: 300;
+  margin: 15px 0;
+  color: #2c3e50;
+}
+header h3 {
+  color: #18537a;
+  font-weight: 300;
+}
+/*****************************Section Styles**************/
+section {
+  margin: 14px 0;
+}
+
+.currentSite {
+  width: 20rem;
+  position: relative;
+}
+.currentSite li {
+  background-color: #9999a8;
+}
+
+/*****************************LIST STYLES*****************************/
+
+h3 {
+  text-align: center;
+  color: yellowgreen;
+  font-size: large;
+  font-weight: 300;
+  margin: 0;
+}
+
+li {
+  list-style: none;
+}
+.list {
+  position: relative;
+  width: 20rem;
+  margin: 0;
+  padding: 2px;
+}
+.siteStats {
+  width: 100%;
+  height: auto;
+  line-height: 1.5;
+  font-size: 20px;
+  padding: 0 2px;
+  color: #34495e;
+  transition: all 0.3s ease;
+}
+.siteStats:hover {
+  cursor: pointer;
+}
+
+span.hostname {
+  color: red;
+}
+
+span.timeSpent {
+  color: blue;
+  position: absolute;
+  right: 0px;
+}

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -1,11 +1,12 @@
-@import url("https://fonts.googleapis.com/css?family=Montserrat:300,400,700");
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Serif:wght@500&family=Kreon:wght@600&family=Montserrat:wght@300;400;700&display=swap");
 
 body {
   margin-top: 0px;
   font-family: "Montserrat", sans-serif;
   background: #ecf0f1;
+  background-color: #cdc9c3;
   height: auto;
-  width: 20rem;
+  /* width: 20rem; */
 }
 
 /*****************************HEADER STYLES*****************************/
@@ -14,10 +15,12 @@ header {
   text-align: center;
 }
 header h1 {
+  font-family: "Kreon", serif;
   font-size: 2.7rem;
   font-weight: 300;
   margin: 15px 0;
   color: #2c3e50;
+  color: #333456;
 }
 header h3 {
   color: #18537a;
@@ -39,11 +42,13 @@ section {
 /*****************************LIST STYLES*****************************/
 
 h3 {
+  font-family: "IBM Plex Serif", serif;
   text-align: center;
-  color: yellowgreen;
+  color: #532e1c;
   font-size: large;
   font-weight: 300;
   margin: 0;
+  margin-bottom: 4px;
 }
 
 li {
@@ -69,7 +74,7 @@ li {
 }
 
 span.hostname {
-  color: red;
+  color: #433d3c;
 }
 
 span.timeSpent {

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -1,31 +1,5 @@
 @import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Serif:wght@500&family=Kreon:wght@600&family=Montserrat:wght@300;400;700&display=swap");
 
-body {
-  margin-top: 0px;
-  font-family: "Montserrat", sans-serif;
-  background: #ecf0f1;
-  background-color: #cdc9c3;
-  height: auto;
-  /* width: 20rem; */
-}
-
-/*****************************HEADER STYLES*****************************/
-
-header {
-  text-align: center;
-}
-header h1 {
-  font-family: "Kreon", serif;
-  font-size: 2.7rem;
-  font-weight: 300;
-  margin: 15px 0;
-  color: #2c3e50;
-  color: #333456;
-}
-header h3 {
-  color: #18537a;
-  font-weight: 300;
-}
 /*****************************Section Styles**************/
 section {
   margin: 14px 0;
@@ -37,48 +11,4 @@ section {
 }
 .currentSite li {
   background-color: #9999a8;
-}
-
-/*****************************LIST STYLES*****************************/
-
-h3 {
-  font-family: "IBM Plex Serif", serif;
-  text-align: center;
-  color: #532e1c;
-  font-size: large;
-  font-weight: 300;
-  margin: 0;
-  margin-bottom: 4px;
-}
-
-li {
-  list-style: none;
-}
-.list {
-  position: relative;
-  width: 20rem;
-  margin: 0;
-  padding: 2px;
-}
-.siteStats {
-  width: 100%;
-  height: auto;
-  line-height: 1.5;
-  font-size: 20px;
-  padding: 0 2px;
-  color: #34495e;
-  transition: all 0.3s ease;
-}
-.siteStats:hover {
-  cursor: pointer;
-}
-
-span.hostname {
-  color: #433d3c;
-}
-
-span.timeSpent {
-  color: blue;
-  position: absolute;
-  right: 0px;
 }

--- a/src/views/options.html
+++ b/src/views/options.html
@@ -4,52 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Usage Monitor</title>
-    <link rel="stylesheet" href="../styles/popup.css" />
-    <style>
-      body {
-        background-color: white;
-      }
-      header h1 {
-        text-align: center;
-      }
-      div {
-        margin: auto;
-        width: 400px;
-        padding: 10px;
-      }
-      .btn {
-        outline: none;
-        border: none;
-        cursor: pointer;
-        display: block;
-        position: relative;
-        background-color: #ac2e25;
-        font-size: 16px;
-        font-weight: 300;
-        color: white;
-        text-transform: uppercase;
-        letter-spacing: 2px;
-        padding: 10px 25px;
-        margin: 10px auto 25px;
-        border-radius: 20px;
-        box-shadow: 0 6px #ca4e4a;
-      }
-
-      .btn:hover {
-        box-shadow: 0 4px #ca534f;
-        bottom: -2px;
-      }
-
-      .btn:active {
-        box-shadow: none;
-        bottom: -6px;
-      }
-      .btn {
-        position: fixed;
-        bottom: 0px;
-        right: 12px;
-      }
-    </style>
+    <link rel="stylesheet" href="../styles/common.css" />
+    <link rel="stylesheet" href="../styles/options.css" />
   </head>
   <body>
     <header>

--- a/src/views/options.html
+++ b/src/views/options.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Usage Monitor</title>
+    <link rel="stylesheet" href="../styles/popup.css" />
+    <style>
+      body {
+        background-color: white;
+      }
+      header h1 {
+        text-align: center;
+      }
+      div {
+        margin: auto;
+        width: 400px;
+        padding: 10px;
+      }
+      .btn {
+        outline: none;
+        border: none;
+        cursor: pointer;
+        display: block;
+        position: relative;
+        background-color: #ac2e25;
+        font-size: 16px;
+        font-weight: 300;
+        color: white;
+        text-transform: uppercase;
+        letter-spacing: 2px;
+        padding: 10px 25px;
+        margin: 10px auto 25px;
+        border-radius: 20px;
+        box-shadow: 0 6px #ca4e4a;
+      }
+
+      .btn:hover {
+        box-shadow: 0 4px #ca534f;
+        bottom: -2px;
+      }
+
+      .btn:active {
+        box-shadow: none;
+        bottom: -6px;
+      }
+      .btn {
+        position: fixed;
+        bottom: 0px;
+        right: 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Usage Monitor Stats</h1>
+      <img src="../icons/128.png" />
+    </header>
+    <div class="container">
+      <button class="btn">Reset Stats</button>
+      <ul class="list">
+        <li class="siteStats">
+          <span class="hostname">devlopers.google.com</span>
+          <span class="timeSpent">23s</span>
+        </li>
+        <li class="siteStats">
+          <span class="hostname">mozilla.com</span>
+          <span class="timeSpent">12s</span>
+        </li>
+        <li class="siteStats">
+          <span class="hostname">archive.org</span>
+          <span class="timeSpent">122s</span>
+        </li>
+        <li class="siteStats">
+          <span class="hostname">devlopers.google.com</span>
+          <span class="timeSpent">23s</span>
+        </li>
+        <li class="siteStats">
+          <span class="hostname">mozilla.com</span>
+          <span class="timeSpent">12s</span>
+        </li>
+        <li class="siteStats">
+          <span class="hostname">archive.org</span>
+          <span class="timeSpent">122s</span>
+        </li>
+        <li class="siteStats">
+          <span class="hostname">devlopers.google.com</span>
+          <span class="timeSpent">23s</span>
+        </li>
+        <li class="siteStats">
+          <span class="hostname">mozilla.com</span>
+          <span class="timeSpent">12s</span>
+        </li>
+        <li class="siteStats">
+          <span class="hostname">archive.org</span>
+          <span class="timeSpent">122s</span>
+        </li>
+        <li class="siteStats">
+          <span class="hostname">devlopers.google.com</span>
+          <span class="timeSpent">23s</span>
+        </li>
+        <li class="siteStats">
+          <span class="hostname">mozilla.com</span>
+          <span class="timeSpent">12s</span>
+        </li>
+        <li class="siteStats">
+          <span class="hostname">archive.org</span>
+          <span class="timeSpent">122s</span>
+        </li>
+      </ul>
+    </div>
+  </body>
+</html>

--- a/src/views/options.html
+++ b/src/views/options.html
@@ -13,7 +13,7 @@
       <img src="../icons/128.png" />
     </header>
     <div class="container">
-      <button class="btn">Reset Stats</button>
+      <button class="btn" id="resetBtn">Reset Stats</button>
       <ul class="list">
         <!-- sites will be added here dynamically by js-->
       </ul>

--- a/src/views/options.html
+++ b/src/views/options.html
@@ -15,7 +15,7 @@
     <div class="container">
       <button class="btn">Reset Stats</button>
       <ul class="list">
-        // sites will be added here dynamically by js
+        <!-- sites will be added here dynamically by js-->
       </ul>
     </div>
     <!--Script tags-->

--- a/src/views/options.html
+++ b/src/views/options.html
@@ -15,55 +15,10 @@
     <div class="container">
       <button class="btn">Reset Stats</button>
       <ul class="list">
-        <li class="siteStats">
-          <span class="hostname">devlopers.google.com</span>
-          <span class="timeSpent">23s</span>
-        </li>
-        <li class="siteStats">
-          <span class="hostname">mozilla.com</span>
-          <span class="timeSpent">12s</span>
-        </li>
-        <li class="siteStats">
-          <span class="hostname">archive.org</span>
-          <span class="timeSpent">122s</span>
-        </li>
-        <li class="siteStats">
-          <span class="hostname">devlopers.google.com</span>
-          <span class="timeSpent">23s</span>
-        </li>
-        <li class="siteStats">
-          <span class="hostname">mozilla.com</span>
-          <span class="timeSpent">12s</span>
-        </li>
-        <li class="siteStats">
-          <span class="hostname">archive.org</span>
-          <span class="timeSpent">122s</span>
-        </li>
-        <li class="siteStats">
-          <span class="hostname">devlopers.google.com</span>
-          <span class="timeSpent">23s</span>
-        </li>
-        <li class="siteStats">
-          <span class="hostname">mozilla.com</span>
-          <span class="timeSpent">12s</span>
-        </li>
-        <li class="siteStats">
-          <span class="hostname">archive.org</span>
-          <span class="timeSpent">122s</span>
-        </li>
-        <li class="siteStats">
-          <span class="hostname">devlopers.google.com</span>
-          <span class="timeSpent">23s</span>
-        </li>
-        <li class="siteStats">
-          <span class="hostname">mozilla.com</span>
-          <span class="timeSpent">12s</span>
-        </li>
-        <li class="siteStats">
-          <span class="hostname">archive.org</span>
-          <span class="timeSpent">122s</span>
-        </li>
+        // sites will be added here dynamically by js
       </ul>
     </div>
+    <!--Script tags-->
+    <script type="module" src="../scripts/options.js"></script>
   </body>
 </html>

--- a/src/views/popup.html
+++ b/src/views/popup.html
@@ -1,12 +1,39 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Usage Monitor</title>
-    <script src="../scripts/eventPage.js"></script>
-</head>
-<body>
-    <h1>Hello World!</h1>
-</body>
+    <link rel="stylesheet" href="../styles/popup.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Usage Monitor</h1>
+      <h3>Track total time spent on each website</h3>
+    </header>
+    <section class="currentSite">
+      <h3>Current Site</h3>
+      <li class="siteStats">
+        <span class="hostname">devlopers.google.com</span>
+        <span class="timeSpent">23s</span>
+      </li>
+    </section>
+    <section class="mostUsedSites">
+      <h3>Most Used Sites</h3>
+      <ul class="list">
+        <li class="siteStats">
+          <span class="hostname">devlopers.google.com</span>
+          <span class="timeSpent">23s</span>
+        </li>
+        <li class="siteStats">
+          <span class="hostname">mozilla.com</span>
+          <span class="timeSpent">12s</span>
+        </li>
+        <li class="siteStats">
+          <span class="hostname">archive.org</span>
+          <span class="timeSpent">122s</span>
+        </li>
+      </ul>
+    </section>
+  </body>
 </html>

--- a/src/views/popup.html
+++ b/src/views/popup.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Usage Monitor</title>
+    <link rel="stylesheet" href="../styles/common.css" />
     <link rel="stylesheet" href="../styles/popup.css" />
   </head>
   <body>

--- a/src/views/popup.html
+++ b/src/views/popup.html
@@ -14,18 +14,18 @@
     </header>
     <section class="currentSite">
       <h3>Current Site</h3>
-      <li class="siteStats">
-        <span class="hostname">devlopers.google.com</span>
-        <span class="timeSpent">23s</span>
-      </li>
+      <div id="currentSite">
+        <li class="siteStats">
+          <span class="hostname">dummyCurrentSite.com</span>
+          <span class="timeSpent">23s</span>
+        </li>
+        <span></span>
+      </div>
     </section>
     <section class="mostUsedSites">
       <h3>Most Used Sites</h3>
       <ul class="list">
-        <li class="siteStats">
-          <span class="hostname">devlopers.google.com</span>
-          <span class="timeSpent">23s</span>
-        </li>
+        <!-- sites will be added here dynamically by js-->
       </ul>
       <p>
         visit <a href="options.html" target="_blank">options page</a> to reset

--- a/src/views/popup.html
+++ b/src/views/popup.html
@@ -34,6 +34,10 @@
           <span class="timeSpent">122s</span>
         </li>
       </ul>
+      <p>
+        visit <a href="options.html" target="_blank">options page</a> to reset
+        and view full data
+      </p>
     </section>
   </body>
 </html>

--- a/src/views/popup.html
+++ b/src/views/popup.html
@@ -26,19 +26,12 @@
           <span class="hostname">devlopers.google.com</span>
           <span class="timeSpent">23s</span>
         </li>
-        <li class="siteStats">
-          <span class="hostname">mozilla.com</span>
-          <span class="timeSpent">12s</span>
-        </li>
-        <li class="siteStats">
-          <span class="hostname">archive.org</span>
-          <span class="timeSpent">122s</span>
-        </li>
       </ul>
       <p>
         visit <a href="options.html" target="_blank">options page</a> to reset
         and view full data
       </p>
     </section>
+    <script type="module" src="../scripts/popup.js"></script>
   </body>
 </html>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
popup page and options page , both retrieve the list of sites and their time usage. and then inserts it into 
DOM.

popup page will also sort by timeSpent and show 5 most used site by timeSpent.



## Related Issue
resolves #13 
<!--- Please link to the issue here: -->

# Checklist
- [ ] Test
- [ ] Translations
- [ ] Documentations

## How Has This Been Tested?
it has been tested in chrome browser.
see screenshots.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Motivation and Context
 *Why is this change required? What problem does it solve?*
there was no frontend to data stored by extension. so it was required to display the data and provide
user an interface through which they can see stats and reset.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

# Screenshots
![pr1](https://user-images.githubusercontent.com/63513250/103150210-e0146980-4797-11eb-8656-8075ea40b3ec.png)
![pr2](https://user-images.githubusercontent.com/63513250/103150215-e86ca480-4797-11eb-9e8c-97f8bf66c7f5.png)


## Additional Info
 *Any additional info regarding this PR.*

Please use the [Gitter](https://gitter.im/the-browser-toolbox/community) channel to update about your pull request.
